### PR TITLE
add a -fpsquiet option

### DIFF
--- a/unlockfps/main.cpp
+++ b/unlockfps/main.cpp
@@ -284,8 +284,14 @@ int main(int argc, char** argv)
     std::string CommandLine{};
     if (argc > 1)
     {
-        for (int i = 1; i < argc; i++)
+        for (int i = 1; i < argc; i++) {
+            if(strstr(argv[i], "-fpsquiet")) {
+                FreeConsole();
+                continue;
+            };
+            
             CommandLine += argv[i] + std::string(" ");
+        }
     }
 
     LoadConfig();


### PR DESCRIPTION
adds an option to launch the program with no console

https://github.com/34736384/genshin-fps-unlock/issues/45