### PR TITLE
Fix DLL injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Program files
+fps_config.json

--- a/unlockfps_clr.sln
+++ b/unlockfps_clr.sln
@@ -8,19 +8,13 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
 		Release|x64 = Release|x64
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A44A2C76-9D37-4D59-9020-AE1A0006C3A1}.Debug|x64.ActiveCfg = Debug|x64
 		{A44A2C76-9D37-4D59-9020-AE1A0006C3A1}.Debug|x64.Build.0 = Debug|x64
-		{A44A2C76-9D37-4D59-9020-AE1A0006C3A1}.Debug|x86.ActiveCfg = Debug|Win32
-		{A44A2C76-9D37-4D59-9020-AE1A0006C3A1}.Debug|x86.Build.0 = Debug|Win32
 		{A44A2C76-9D37-4D59-9020-AE1A0006C3A1}.Release|x64.ActiveCfg = Release|x64
 		{A44A2C76-9D37-4D59-9020-AE1A0006C3A1}.Release|x64.Build.0 = Release|x64
-		{A44A2C76-9D37-4D59-9020-AE1A0006C3A1}.Release|x86.ActiveCfg = Release|Win32
-		{A44A2C76-9D37-4D59-9020-AE1A0006C3A1}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/unlockfps_clr/MainForm.cpp
+++ b/unlockfps_clr/MainForm.cpp
@@ -174,8 +174,6 @@ namespace unlockfpsclr
 			if (!Unmanaged::SetupData())
 				continue;
 
-			Managed::InjectDLLs(settings->DllList);
-
 			while (!worker->CancellationPending)
 			{
 				Unmanaged::ApplyFPS(settings->FPSTarget, settings->UsePowerSave);

--- a/unlockfps_clr/Managed.cpp
+++ b/unlockfps_clr/Managed.cpp
@@ -135,5 +135,14 @@ bool Managed::StartGame(Settings^ settings)
     Marshal::FreeHGlobal(static_cast<IntPtr>(nativeCommandLine));
     Marshal::FreeHGlobal(static_cast<IntPtr>(nativeGamePath));
 
+    // Wait for a process with the target name to spawn
+    while (!(Unmanaged::GetPID("GenshinImpact.exe") || Unmanaged::GetPID("YuanShen.exe")))
+    {
+        Sleep(1);
+    }
+
+    // Inject DLLs right after launch
+    Managed::InjectDLLs(settings->DllList);
+
     return result;
 }

--- a/unlockfps_clr/unlockfps_clr.vcxproj
+++ b/unlockfps_clr/unlockfps_clr.vcxproj
@@ -85,7 +85,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <WarningLevel>TurnOffAllWarnings</WarningLevel>
+      <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <BufferSecurityCheck>false</BufferSecurityCheck>
@@ -108,7 +108,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>TurnOffAllWarnings</WarningLevel>
+      <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <BufferSecurityCheck>false</BufferSecurityCheck>


### PR DESCRIPTION
Fixes #222 #197
Inject DLL as soon as the process is launched. Injecting them later fails on `CreateRemoteThread()` with error code 5 "Access Denied".

Tested with 3DMigoto (GIMI) and ReShade.