### PR TITLE
Enable HDR feature through Windows registry modification

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
  - Handle protection bypass is already included
  - Does not require a driver for R/W access
  - Supports OS and CN version
+ - Supports enabling HDR feature through Windows registry modification
  - Should work for future updates
  - If the source needs to be updated, I'll try to do it as soon as possible
  - You can download the compiled binary over at '[Release](https://github.com/34736384/genshin-fps-unlock/releases)' if you don't want to compile it yourself

--- a/unlockfps_clr/MainForm.cpp
+++ b/unlockfps_clr/MainForm.cpp
@@ -135,6 +135,7 @@ namespace unlockfpsclr
 		settings->FPSTarget = std::clamp(settings->FPSTarget, tbFPS->Minimum, tbFPS->Maximum); // sanitize
 
 		ckbAutoStart->DataBindings->Add("Checked", settings, "AutoStart");
+		ckbHDR->DataBindings->Add("Checked", settings, "EnableHdr");
 		tbFPS->DataBindings->Add("Value", settings, "FPSTarget", false, DataSourceUpdateMode::OnPropertyChanged);
 		inputFPS->DataBindings->Add("Value", settings, "FPSTarget", false, DataSourceUpdateMode::OnPropertyChanged);
 

--- a/unlockfps_clr/MainForm.h
+++ b/unlockfps_clr/MainForm.h
@@ -67,6 +67,8 @@ namespace unlockfpsclr {
 	private: System::Windows::Forms::ContextMenuStrip^ contextMenuNotify;
 	private: System::Windows::Forms::ToolStripMenuItem^ toolStripMenuExit;
 	private: System::Windows::Forms::ToolStripMenuItem^ menuItemAbout;
+	private: System::Windows::Forms::CheckBox^ ckbHDR;
+
 
 
 
@@ -115,6 +117,7 @@ namespace unlockfpsclr {
 			this->notifyIcon = (gcnew System::Windows::Forms::NotifyIcon(this->components));
 			this->contextMenuNotify = (gcnew System::Windows::Forms::ContextMenuStrip(this->components));
 			this->toolStripMenuExit = (gcnew System::Windows::Forms::ToolStripMenuItem());
+			this->ckbHDR = (gcnew System::Windows::Forms::CheckBox());
 			(cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->tbFPS))->BeginInit();
 			(cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->inputFPS))->BeginInit();
 			this->menuStrip1->SuspendLayout();
@@ -123,9 +126,9 @@ namespace unlockfpsclr {
 			// 
 			// btnStartGame
 			// 
-			this->btnStartGame->Location = System::Drawing::Point(197, 80);
+			this->btnStartGame->Location = System::Drawing::Point(197, 95);
 			this->btnStartGame->Name = L"btnStartGame";
-			this->btnStartGame->Size = System::Drawing::Size(75, 23);
+			this->btnStartGame->Size = System::Drawing::Size(75, 21);
 			this->btnStartGame->TabIndex = 0;
 			this->btnStartGame->TabStop = false;
 			this->btnStartGame->Text = L"Start Game";
@@ -135,9 +138,9 @@ namespace unlockfpsclr {
 			// ckbAutoStart
 			// 
 			this->ckbAutoStart->AutoSize = true;
-			this->ckbAutoStart->Location = System::Drawing::Point(15, 84);
+			this->ckbAutoStart->Location = System::Drawing::Point(15, 100);
 			this->ckbAutoStart->Name = L"ckbAutoStart";
-			this->ckbAutoStart->Size = System::Drawing::Size(144, 17);
+			this->ckbAutoStart->Size = System::Drawing::Size(168, 16);
 			this->ckbAutoStart->TabIndex = 1;
 			this->ckbAutoStart->TabStop = false;
 			this->ckbAutoStart->Text = L"Start Game Automatically";
@@ -154,11 +157,11 @@ namespace unlockfpsclr {
 			// 
 			this->tbFPS->AutoSize = false;
 			this->tbFPS->Cursor = System::Windows::Forms::Cursors::Hand;
-			this->tbFPS->Location = System::Drawing::Point(15, 57);
+			this->tbFPS->Location = System::Drawing::Point(15, 53);
 			this->tbFPS->Maximum = 360;
 			this->tbFPS->Minimum = 1;
 			this->tbFPS->Name = L"tbFPS";
-			this->tbFPS->Size = System::Drawing::Size(257, 21);
+			this->tbFPS->Size = System::Drawing::Size(257, 19);
 			this->tbFPS->TabIndex = 2;
 			this->tbFPS->TabStop = false;
 			this->tbFPS->TickStyle = System::Windows::Forms::TickStyle::None;
@@ -167,19 +170,19 @@ namespace unlockfpsclr {
 			// labelFPS
 			// 
 			this->labelFPS->AutoSize = true;
-			this->labelFPS->Location = System::Drawing::Point(12, 33);
+			this->labelFPS->Location = System::Drawing::Point(12, 30);
 			this->labelFPS->Name = L"labelFPS";
-			this->labelFPS->Size = System::Drawing::Size(33, 13);
+			this->labelFPS->Size = System::Drawing::Size(35, 12);
 			this->labelFPS->TabIndex = 3;
 			this->labelFPS->Text = L"FPS: ";
 			// 
 			// inputFPS
 			// 
-			this->inputFPS->Location = System::Drawing::Point(48, 31);
+			this->inputFPS->Location = System::Drawing::Point(48, 29);
 			this->inputFPS->Maximum = System::Decimal(gcnew cli::array< System::Int32 >(4) { 360, 0, 0, 0 });
 			this->inputFPS->Minimum = System::Decimal(gcnew cli::array< System::Int32 >(4) { 1, 0, 0, 0 });
 			this->inputFPS->Name = L"inputFPS";
-			this->inputFPS->Size = System::Drawing::Size(224, 20);
+			this->inputFPS->Size = System::Drawing::Size(224, 21);
 			this->inputFPS->TabIndex = 4;
 			this->inputFPS->TabStop = false;
 			this->inputFPS->Value = System::Decimal(gcnew cli::array< System::Int32 >(4) { 120, 0, 0, 0 });
@@ -189,7 +192,7 @@ namespace unlockfpsclr {
 			this->menuStrip1->Items->AddRange(gcnew cli::array< System::Windows::Forms::ToolStripItem^  >(1) { this->toolStripMenuItem });
 			this->menuStrip1->Location = System::Drawing::Point(0, 0);
 			this->menuStrip1->Name = L"menuStrip1";
-			this->menuStrip1->Size = System::Drawing::Size(284, 24);
+			this->menuStrip1->Size = System::Drawing::Size(284, 25);
 			this->menuStrip1->TabIndex = 5;
 			this->menuStrip1->Text = L"menuStrip1";
 			// 
@@ -200,27 +203,27 @@ namespace unlockfpsclr {
 					this->menuItemSetup, this->menuItemAbout
 			});
 			this->toolStripMenuItem->Name = L"toolStripMenuItem";
-			this->toolStripMenuItem->Size = System::Drawing::Size(61, 20);
+			this->toolStripMenuItem->Size = System::Drawing::Size(66, 21);
 			this->toolStripMenuItem->Text = L"Options";
 			// 
 			// menuItemSettings
 			// 
 			this->menuItemSettings->Name = L"menuItemSettings";
-			this->menuItemSettings->Size = System::Drawing::Size(116, 22);
+			this->menuItemSettings->Size = System::Drawing::Size(180, 22);
 			this->menuItemSettings->Text = L"Settings";
 			this->menuItemSettings->Click += gcnew System::EventHandler(this, &MainForm::settingsMenuItem_Click);
 			// 
 			// menuItemSetup
 			// 
 			this->menuItemSetup->Name = L"menuItemSetup";
-			this->menuItemSetup->Size = System::Drawing::Size(116, 22);
+			this->menuItemSetup->Size = System::Drawing::Size(180, 22);
 			this->menuItemSetup->Text = L"Setup";
 			this->menuItemSetup->Click += gcnew System::EventHandler(this, &MainForm::setupMenuItem_Click);
 			// 
 			// menuItemAbout
 			// 
 			this->menuItemAbout->Name = L"menuItemAbout";
-			this->menuItemAbout->Size = System::Drawing::Size(116, 22);
+			this->menuItemAbout->Size = System::Drawing::Size(180, 22);
 			this->menuItemAbout->Text = L"About";
 			this->menuItemAbout->Click += gcnew System::EventHandler(this, &MainForm::menuItemAbout_Click);
 			// 
@@ -244,20 +247,34 @@ namespace unlockfpsclr {
 			this->contextMenuNotify->Items->AddRange(gcnew cli::array< System::Windows::Forms::ToolStripItem^  >(1) { this->toolStripMenuExit });
 			this->contextMenuNotify->Name = L"contextMenuNotify";
 			this->contextMenuNotify->ShowItemToolTips = false;
-			this->contextMenuNotify->Size = System::Drawing::Size(94, 26);
+			this->contextMenuNotify->Size = System::Drawing::Size(97, 26);
 			// 
 			// toolStripMenuExit
 			// 
 			this->toolStripMenuExit->Name = L"toolStripMenuExit";
-			this->toolStripMenuExit->Size = System::Drawing::Size(93, 22);
+			this->toolStripMenuExit->Size = System::Drawing::Size(96, 22);
 			this->toolStripMenuExit->Text = L"Exit";
 			this->toolStripMenuExit->Click += gcnew System::EventHandler(this, &MainForm::toolStripMenuExit_Click);
 			// 
+			// ckbHDR
+			// 
+			this->ckbHDR->AutoSize = true;
+			this->ckbHDR->Location = System::Drawing::Point(15, 78);
+			this->ckbHDR->Name = L"ckbHDR";
+			this->ckbHDR->Size = System::Drawing::Size(84, 16);
+			this->ckbHDR->TabIndex = 6;
+			this->ckbHDR->TabStop = false;
+			this->ckbHDR->Text = L"Enable HDR";
+			this->ttAutoStart->SetToolTip(this->ckbHDR, L"This will take effect on subsequent launch");
+			this->ckbHDR->UseVisualStyleBackColor = true;
+			this->ckbHDR->CheckedChanged += gcnew System::EventHandler(this, &MainForm::checkBox1_CheckedChanged);
+			// 
 			// MainForm
 			// 
-			this->AutoScaleDimensions = System::Drawing::SizeF(6, 13);
+			this->AutoScaleDimensions = System::Drawing::SizeF(6, 12);
 			this->AutoScaleMode = System::Windows::Forms::AutoScaleMode::Font;
-			this->ClientSize = System::Drawing::Size(284, 115);
+			this->ClientSize = System::Drawing::Size(284, 126);
+			this->Controls->Add(this->ckbHDR);
 			this->Controls->Add(this->inputFPS);
 			this->Controls->Add(this->labelFPS);
 			this->Controls->Add(this->tbFPS);
@@ -292,5 +309,7 @@ namespace unlockfpsclr {
 	private: Void toolStripMenuExit_Click(Object^ sender, EventArgs^ e);
 	private: Void OnFormClosing(Object^ sender, FormClosingEventArgs^ e);
 	private: Void menuItemAbout_Click(Object^ sender, EventArgs^ e);
+private: System::Void checkBox1_CheckedChanged(System::Object^ sender, System::EventArgs^ e) {
+}
 };
 }

--- a/unlockfps_clr/Managed.cpp
+++ b/unlockfps_clr/Managed.cpp
@@ -44,7 +44,7 @@ List<String^>^ Managed::TryResolveGamePath()
         for each (auto it in SubKeys)
         {
             auto SubKeyName = it;
-            if (!SubKeyName->Contains("Genshin Impact") && !SubKeyName->Contains(L"Ô­Éñ"))
+            if (!SubKeyName->Contains("Genshin Impact") && !SubKeyName->Contains(L"åŽŸç¥ž"))
                 continue;
 
             auto SubKey = Uninstall->OpenSubKey(SubKeyName);

--- a/unlockfps_clr/Managed.cpp
+++ b/unlockfps_clr/Managed.cpp
@@ -116,6 +116,11 @@ bool Managed::StartGame(Settings^ settings)
         return false;
     }
 
+    if (settings->EnableHdr) {
+        Unmanaged::registerHDREntry();
+    }
+    
+
     String^ commandLine = "";
 
     if (settings->PopupWindow)

--- a/unlockfps_clr/Settings.cpp
+++ b/unlockfps_clr/Settings.cpp
@@ -22,6 +22,7 @@ Settings^ Settings::InitializeDefaults()
     UseCustomRes = false;
     IsExclusiveFullscreen = false;
     UsePowerSave = false;
+    EnableHdr = false;
 
     FPSTarget = 120;
     CustomResX = 1920;

--- a/unlockfps_clr/Settings.h
+++ b/unlockfps_clr/Settings.h
@@ -19,6 +19,7 @@ public:
 	property bool IsExclusiveFullscreen;
 	property bool StartMinimized;
 	property bool UsePowerSave;
+	property bool EnableHdr;
 
 	property int FPSTarget;
 	property int CustomResX;

--- a/unlockfps_clr/Unmanaged.cpp
+++ b/unlockfps_clr/Unmanaged.cpp
@@ -395,24 +395,22 @@ bool Unmanaged::VerifyDLL(PVOID module)
 
 void Unmanaged::registerHDREntry()
 {
-    // 定义注册表路径和要修改的键名
+    // define registry path and value name
     HKEY hKey;
-    LPCWSTR regPath = L"SOFTWARE\\miHoYo\\原神";
+    LPCWSTR regPath = L"SOFTWARE\\miHoYo\\鍘熺";
     LPCWSTR regValueName = L"WINDOWS_HDR_ON_h3132281285";
 
-    // 打开或创建注册表项
+    // open or create registry entry
     LONG result = RegCreateKeyExW(HKEY_CURRENT_USER, regPath, 0, NULL, 0, KEY_WRITE, NULL, &hKey, NULL);
     if (result == ERROR_SUCCESS) {
-        // 设置要写入的新值
         DWORD newValue = 1;
-
-        // 写入注册表值
+        // set the registry value
         result = RegSetValueExW(hKey, regValueName, 0, REG_DWORD, (BYTE*)&newValue, sizeof(newValue));
         if (result != ERROR_SUCCESS) {
             std::string message = "Failed to change HDR registry";
             MessageBoxA(nullptr, message.c_str(), "Error", MB_OK | MB_ICONERROR);
         }
-        // 关闭注册表项
+        // close registry
         RegCloseKey(hKey);
     }
     else {

--- a/unlockfps_clr/Unmanaged.cpp
+++ b/unlockfps_clr/Unmanaged.cpp
@@ -393,4 +393,32 @@ bool Unmanaged::VerifyDLL(PVOID module)
     return ntHeader->FileHeader.Machine == IMAGE_FILE_MACHINE_AMD64;
 }
 
+void Unmanaged::registerHDREntry()
+{
+    // 定义注册表路径和要修改的键名
+    HKEY hKey;
+    LPCWSTR regPath = L"SOFTWARE\\miHoYo\\原神";
+    LPCWSTR regValueName = L"WINDOWS_HDR_ON_h3132281285";
+
+    // 打开或创建注册表项
+    LONG result = RegCreateKeyExW(HKEY_CURRENT_USER, regPath, 0, NULL, 0, KEY_WRITE, NULL, &hKey, NULL);
+    if (result == ERROR_SUCCESS) {
+        // 设置要写入的新值
+        DWORD newValue = 1;
+
+        // 写入注册表值
+        result = RegSetValueExW(hKey, regValueName, 0, REG_DWORD, (BYTE*)&newValue, sizeof(newValue));
+        if (result != ERROR_SUCCESS) {
+            std::string message = "Failed to change HDR registry";
+            MessageBoxA(nullptr, message.c_str(), "Error", MB_OK | MB_ICONERROR);
+        }
+        // 关闭注册表项
+        RegCloseKey(hKey);
+    }
+    else {
+        std::string message = "Failed to open or create HDR registry";
+        MessageBoxA(nullptr, message.c_str(), "Error", MB_OK | MB_ICONERROR);
+    }
+}
+
 #pragma managed

--- a/unlockfps_clr/Unmanaged.h
+++ b/unlockfps_clr/Unmanaged.h
@@ -33,6 +33,7 @@ namespace Unmanaged
 	bool SetupData();
 	bool ShowError(std::string apiName, DWORD code);
 	bool VerifyDLL(PVOID module);
+	void registerHDREntry();
 
 	DWORD GetPID(std::string ProcessName);
 	uintptr_t PatternScan(PVOID module, LPCSTR signature);

--- a/unlockfps_clr/unlockfps_clr.vcxproj
+++ b/unlockfps_clr/unlockfps_clr.vcxproj
@@ -44,14 +44,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -80,7 +80,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies />
+      <AdditionalDependencies>Advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -92,7 +92,7 @@
       <AdditionalOptions>/Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies />
+      <AdditionalDependencies>Advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
       <EntryPointSymbol>main</EntryPointSymbol>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
@@ -104,7 +104,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies />
+      <AdditionalDependencies>Advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -123,6 +123,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention>false</DataExecutionPrevention>
+      <AdditionalDependencies>Advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/unlockfps_clr/unlockfps_clr.vcxproj
+++ b/unlockfps_clr/unlockfps_clr.vcxproj
@@ -44,14 +44,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -80,7 +80,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies />
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -92,7 +92,7 @@
       <AdditionalOptions>/Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies />
       <SubSystem>Windows</SubSystem>
       <EntryPointSymbol>main</EntryPointSymbol>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
@@ -104,7 +104,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies />
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -123,7 +123,6 @@
       <OptimizeReferences>true</OptimizeReferences>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention>false</DataExecutionPrevention>
-      <AdditionalDependencies>Advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Now Genshin Impact suppurts native HDR feature (not quite offically) if we create a Windows registry entry.
So this PR adds a checkbox; when selected, it will set specific registry entries to enable HDR.

================================
现在原神其实支持原生的 hdr 功能，把注册表某个条目设置了就行。（但官方貌似没有集成到自己的设置页面里，不知道为什么）
所以这个 pr 就是加了个 checkbox，如果选中的话，就会去设置一下那个注册表，亲测可用
不过我的可用版本是在 v142 的环境下编出来的，v143 的环境我的 vs 安装不了，但为了和本 repo 一致我这个 pr 里还是用的 v143 环境。
另外国际服的注册表路径不是很确定，可能和本pr不一致，未测试过。