### PR TITLE
Add game path to command line

### DIFF
--- a/unlockfps_clr/Managed.cpp
+++ b/unlockfps_clr/Managed.cpp
@@ -116,7 +116,7 @@ bool Managed::StartGame(Settings^ settings)
         return false;
     }
 
-    String^ commandLine = "";
+    String^ commandLine = String::Format("\"{0}\" ", settings->GamePath);
 
     if (settings->PopupWindow)
         commandLine += "-popupwindow ";


### PR DESCRIPTION
[Microsoft documentation states](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa):
> If both lpApplicationName and lpCommandLine are non-NULL, the null-terminated string pointed to by lpApplicationName specifies the module to execute, and the null-terminated string pointed to by lpCommandLine specifies the command line. The new process can use GetCommandLine to retrieve the entire command line. Console processes written in C can use the argc and argv arguments to parse the command line. Because argv[0] is the module name, **C programmers generally repeat the module name as the first token in the command line**.

The current implementation doesn't repeat it, which causes some issues on non-Windows platforms. In particular, the process name is set to the first token in the command line, leading to it being named weird things like `-screen-fullscreen`.

This pull request fixes the issue.