### PR TITLE
Small fixes to minor issues such as mobile UI options not working properly.

### DIFF
--- a/unlockfps_nc/MainForm.Designer.cs
+++ b/unlockfps_nc/MainForm.Designer.cs
@@ -145,7 +145,7 @@
             NotifyIconMain.BalloonTipTitle = "FPS Unlcoker";
             NotifyIconMain.ContextMenuStrip = ContextNotify;
             NotifyIconMain.Icon = (Icon)resources.GetObject("NotifyIconMain.Icon");
-            NotifyIconMain.Text = "Hello";
+            NotifyIconMain.Text = "FPS Unlcoker";
             NotifyIconMain.Visible = true;
             NotifyIconMain.DoubleClick += NotifyIconMain_DoubleClick;
             // 

--- a/unlockfps_nc/Service/ProcessService.cs
+++ b/unlockfps_nc/Service/ProcessService.cs
@@ -178,10 +178,10 @@ namespace unlockfps_nc.Service
 
             commandLine += $"-screen-fullscreen {(_config.Fullscreen ? 1 : 0)} ";
             if (_config.Fullscreen)
-                commandLine += $"-window-mode {(_config.IsExclusiveFullscreen ? "exclusive" : "borderless")}";
+                commandLine += $"-window-mode {(_config.IsExclusiveFullscreen ? "exclusive" : "borderless")} ";
 
             if (_config.UseMobileUI)
-                commandLine += "use_mobile_platform -is_cloud 1 -platform_type CLOUD_THIRD_PARTY_MOBILE";
+                commandLine += "use_mobile_platform -is_cloud 1 -platform_type CLOUD_THIRD_PARTY_MOBILE ";
 
             commandLine += $"-monitor {_config.MonitorNum} ";
             return commandLine;

--- a/unlockfps_nc/SettingsForm.Designer.cs
+++ b/unlockfps_nc/SettingsForm.Designer.cs
@@ -186,6 +186,7 @@
             CBUseMobileUI.TabIndex = 11;
             CBUseMobileUI.Text = "Use Mobile UI";
             CBUseMobileUI.UseVisualStyleBackColor = true;
+            CBUseMobileUI.CheckStateChanged += LaunchOptionsChanged;
             // 
             // InputMonitorNum
             // 

--- a/unlockfps_nc/SettingsForm.cs
+++ b/unlockfps_nc/SettingsForm.cs
@@ -43,6 +43,7 @@ namespace unlockfps_nc
             InputResY.DataBindings.Add("Value", _config, "CustomResY", true, DataSourceUpdateMode.OnPropertyChanged);
             ComboFullscreenMode.DataBindings.Add("SelectedIndex", _config, "IsExclusiveFullscreen", true, DataSourceUpdateMode.OnPropertyChanged);
             InputMonitorNum.DataBindings.Add("Value", _config, "MonitorNum", true, DataSourceUpdateMode.OnPropertyChanged);
+            CBUseMobileUI.DataBindings.Add("Checked", _config, "UseMobileUI", true, DataSourceUpdateMode.OnPropertyChanged);
 
             // DLLs            
             RefreshDllList();


### PR DESCRIPTION
This is my first pull request submission. I have never used C# and only have some basic knowledge of other programming languages. I apologize for any shortcomings.
1. Fixed the problem that the mobile UI switch is invalid and cannot be saved after closing the window.
2. Fixed the problem that after turning on the switch in the configuration file, the parameter does not take effect because there is a space missing at the end.
3. Change the floating prompt on the taskbar corner icon to the correct name

---
第一次提交pr，没用过c#，只有一点其他编程语言的基础，如有不足望见谅
1.修复移动端UI开关无效，关闭窗口后不能保存
2.修复在配置文件中打开开关后，因为参数最后少了个空格不生效
3.任务栏右下角图标上的悬浮提示改为正确的名字