### PR TITLE
设置窗口位置

### DIFF
--- a/unlockfps_nc/Model/Config.cs
+++ b/unlockfps_nc/Model/Config.cs
@@ -24,6 +24,8 @@ namespace unlockfps_nc.Model
         public int FPSTarget { get; set; } = 120;
         public int CustomResX { get; set; } = 1920;
         public int CustomResY { get; set; } = 1080;
+        public int CustomMoveX { get; set; } = -1;
+        public int CustomMoveY { get; set; } = -1;
         public int MonitorNum { get; set; } = 1;
         public int Priority { get; set; } = 3;
 

--- a/unlockfps_nc/Service/ProcessService.cs
+++ b/unlockfps_nc/Service/ProcessService.cs
@@ -29,6 +29,7 @@ namespace unlockfps_nc.Service
         private IntPtr _gameHandle = IntPtr.Zero;
         private IntPtr _remoteUnityPlayer = IntPtr.Zero;
         private IntPtr _remoteUserAssembly = IntPtr.Zero;
+        private IntPtr _unityWnd = IntPtr.Zero;
         private int _gamePid = 0;
         private bool _gameInForeground = true;
 
@@ -91,6 +92,13 @@ namespace unlockfps_nc.Service
 
             Native.GetWindowThreadProcessId(hWnd, out var pid);
             _gameInForeground = pid == _gamePid;
+
+            if (_gameInForeground && _unityWnd == IntPtr.Zero)
+            {
+                _unityWnd = hWnd;
+                if (_config.PopupWindow && _config.UseCustomRes && _config.CustomMoveX > -1 && _config.CustomMoveY > -1)
+                    Native.MoveWindow(_unityWnd, _config.CustomMoveX, _config.CustomMoveY, _config.CustomResX, _config.CustomResY, true);
+            }
 
             ApplyFpsLimit();
 

--- a/unlockfps_nc/Utility/Native.cs
+++ b/unlockfps_nc/Utility/Native.cs
@@ -15,6 +15,9 @@ namespace unlockfps_nc.Utility
         [DllImport("user32.dll", CharSet = CharSet.Unicode)]
         public static extern IntPtr FindWindow(string lpClassName, string lpWindowName);
 
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        internal static extern bool MoveWindow(IntPtr hWnd, int X, int Y, int nWidth, int nHeight, bool bRepaint);
+
         [DllImport("user32.dll")]
         public static extern bool EnumWindows(EnumWindowsProc enumProc, IntPtr lParam);
 


### PR DESCRIPTION
在 PopupWindow && UseCustomRes 时，窗口是默认居中，且不能移动位置的。因此提供移动窗口的设置。