### PR TITLE
Fix support for linux on wine

### DIFF
--- a/unlockfps_nc/Utility/Native.cs
+++ b/unlockfps_nc/Utility/Native.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -86,6 +86,9 @@ namespace unlockfps_nc.Utility
 
         [DllImport("kernel32.dll")]
         public static extern bool SetPriorityClass(IntPtr hProcess, uint dwPriorityClass);
+
+        [DllImport("kernel32.dll")]
+        public static extern bool IsBadReadPtr(IntPtr lp, UIntPtr ucb);
 
         [DllImport("psapi.dll", SetLastError = true)]
         public static extern bool EnumProcessModules(IntPtr hProcess, [Out] IntPtr[] lphModule, uint cb, out uint lpcbNeeded);

--- a/unlockfps_nc/Utility/ProcessUtils.cs
+++ b/unlockfps_nc/Utility/ProcessUtils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.PortableExecutable;
@@ -89,6 +89,11 @@ namespace unlockfps_nc.Utility
 
             for (var i = 0U; i < sizeOfImage - s; i++)
             {
+                if (Native.IsBadReadPtr((IntPtr) (module.ToInt64() + i), (UIntPtr) s))
+                {
+                    continue;
+                }
+
                 var found = true;
                 for (var j = 0; j < s; j++)
                 {


### PR DESCRIPTION
This is an odd one, but it appears that LoadLibraryEx at least in the current proton/wine version does not return a single long buffer and instead has some holes in it. I couldn't pinpoint where those holes where, but `IsBadReadPtr` is meant for exactly this purpose. With it in place the pattern search works again.