### PR TITLE
Fix FreeLibrary call

### DIFF
--- a/unlockfps_nc/Utility/Native.cs
+++ b/unlockfps_nc/Utility/Native.cs
@@ -102,16 +102,16 @@ namespace unlockfps_nc.Utility
 
     internal class ModuleGuard(IntPtr module) : IDisposable
     {
-        public IntPtr BaseAddress { get; private set; } = module;
+        public IntPtr BaseAddress { get => module & ~3; }
 
-        public static implicit operator ModuleGuard(IntPtr module) => new(module & ~3);
+        public static implicit operator ModuleGuard(IntPtr module) => new(module);
         public static implicit operator IntPtr(ModuleGuard guard) => guard.BaseAddress;
         public static implicit operator bool(ModuleGuard guard) => guard.BaseAddress != IntPtr.Zero;
 
         public void Dispose()
         {
             if (this)
-                Native.FreeLibrary(BaseAddress);
+                Native.FreeLibrary(module);
         }
     }
 


### PR DESCRIPTION
The `FreeLibrary` should be called with original HMODULE to properly free the library.
Call `FreeLibrary` with the mapped view handle results to a no-op.

Related:

https://github.com/DGP-Studio/Snap.Hutao/issues/1703
https://github.com/DGP-Studio/Snap.Hutao/commit/82e6b62231057e69ff9d2398b21602ff6f024800