### PR TITLE
Added official HDR support and Processor Affinity

### DIFF
--- a/unlockfps_nc/Model/Config.cs
+++ b/unlockfps_nc/Model/Config.cs
@@ -20,12 +20,14 @@ namespace unlockfps_nc.Model
         public bool UsePowerSave { get; set; }
         public bool SuspendLoad { get; set; }
         public bool UseMobileUI { get; set; }
+        public bool UseHDR { get; set; }
 
         public int FPSTarget { get; set; } = 120;
         public int CustomResX { get; set; } = 1920;
         public int CustomResY { get; set; } = 1080;
         public int MonitorNum { get; set; } = 1;
         public int Priority { get; set; } = 3;
+        public int Affinity { get; set; } = 0;
 
         public List<string> DllList { get; set; } = new();
     }

--- a/unlockfps_nc/SettingsForm.Designer.cs
+++ b/unlockfps_nc/SettingsForm.Designer.cs
@@ -37,6 +37,9 @@
             CBPowerSave = new CheckBox();
             CBAutoClose = new CheckBox();
             CBStartMinimized = new CheckBox();
+            CBUseHDR = new CheckBox();
+            InputAffinityNum = new NumericUpDown();
+            LabelAffinity = new Label();
             TabLaunchOptions = new TabPage();
             CBUseMobileUI = new CheckBox();
             InputMonitorNum = new NumericUpDown();
@@ -61,14 +64,15 @@
             TabCtrlSettings.SuspendLayout();
             TabGeneral.SuspendLayout();
             TabLaunchOptions.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)InputAffinityNum).BeginInit();
             ((System.ComponentModel.ISupportInitialize)InputMonitorNum).BeginInit();
             ((System.ComponentModel.ISupportInitialize)InputResY).BeginInit();
             ((System.ComponentModel.ISupportInitialize)InputResX).BeginInit();
             TabDlls.SuspendLayout();
             SuspendLayout();
-            // 
+            //
             // LabelAutoSave
-            // 
+            //
             LabelAutoSave.AutoSize = true;
             LabelAutoSave.Font = new Font("Segoe UI", 9F, FontStyle.Bold, GraphicsUnit.Point, 0);
             LabelAutoSave.Location = new Point(12, 9);
@@ -76,9 +80,9 @@
             LabelAutoSave.Size = new Size(219, 15);
             LabelAutoSave.TabIndex = 0;
             LabelAutoSave.Text = "All settings will be saved automatically";
-            // 
+            //
             // TabCtrlSettings
-            // 
+            //
             TabCtrlSettings.Controls.Add(TabGeneral);
             TabCtrlSettings.Controls.Add(TabLaunchOptions);
             TabCtrlSettings.Controls.Add(TabDlls);
@@ -87,14 +91,17 @@
             TabCtrlSettings.SelectedIndex = 0;
             TabCtrlSettings.Size = new Size(260, 222);
             TabCtrlSettings.TabIndex = 1;
-            // 
+            //
             // TabGeneral
-            // 
+            //
             TabGeneral.Controls.Add(ComboPriority);
             TabGeneral.Controls.Add(LabelPriority);
             TabGeneral.Controls.Add(CBPowerSave);
             TabGeneral.Controls.Add(CBAutoClose);
             TabGeneral.Controls.Add(CBStartMinimized);
+            TabGeneral.Controls.Add(CBUseHDR);
+            TabGeneral.Controls.Add(InputAffinityNum);
+            TabGeneral.Controls.Add(LabelAffinity);
             TabGeneral.Location = new Point(4, 24);
             TabGeneral.Name = "TabGeneral";
             TabGeneral.Padding = new Padding(3);
@@ -102,28 +109,28 @@
             TabGeneral.TabIndex = 0;
             TabGeneral.Text = "General";
             TabGeneral.UseVisualStyleBackColor = true;
-            // 
+            //
             // ComboPriority
-            // 
+            //
             ComboPriority.FormattingEnabled = true;
             ComboPriority.Items.AddRange(new object[] { "Realtime", "High", "Above Normal", "Normal", "Below Normal", "Low" });
-            ComboPriority.Location = new Point(125, 82);
+            ComboPriority.Location = new Point(128, 78);
             ComboPriority.Name = "ComboPriority";
             ComboPriority.Size = new Size(121, 23);
             ComboPriority.TabIndex = 5;
             ComboPriority.Text = "Normal";
-            // 
+            //
             // LabelPriority
-            // 
+            //
             LabelPriority.AutoSize = true;
-            LabelPriority.Location = new Point(3, 85);
+            LabelPriority.Location = new Point(3, 81);
             LabelPriority.Name = "LabelPriority";
             LabelPriority.Size = new Size(122, 15);
             LabelPriority.TabIndex = 4;
             LabelPriority.Text = "Game Process Priority";
-            // 
+            //
             // CBPowerSave
-            // 
+            //
             CBPowerSave.AutoSize = true;
             CBPowerSave.Location = new Point(6, 56);
             CBPowerSave.Name = "CBPowerSave";
@@ -132,9 +139,9 @@
             CBPowerSave.Text = "Power Saving";
             ToolTipSettings.SetToolTip(CBPowerSave, "Sets fps to 10 and low process priority upon losing focus (e.g. tabbing out of game)");
             CBPowerSave.UseVisualStyleBackColor = true;
-            // 
+            //
             // CBAutoClose
-            // 
+            //
             CBAutoClose.AutoSize = true;
             CBAutoClose.Location = new Point(6, 31);
             CBAutoClose.Name = "CBAutoClose";
@@ -143,9 +150,9 @@
             CBAutoClose.Text = "Auto Close";
             ToolTipSettings.SetToolTip(CBAutoClose, "Unlocker will exit upon game closing");
             CBAutoClose.UseVisualStyleBackColor = true;
-            // 
+            //
             // CBStartMinimized
-            // 
+            //
             CBStartMinimized.AutoSize = true;
             CBStartMinimized.Location = new Point(6, 6);
             CBStartMinimized.Name = "CBStartMinimized";
@@ -154,9 +161,38 @@
             CBStartMinimized.Text = "Start Minimized (Unlocker)";
             ToolTipSettings.SetToolTip(CBStartMinimized, "Unlocker will minimized to tray on starup");
             CBStartMinimized.UseVisualStyleBackColor = true;
-            // 
+            //
+            // CBUseHDR
+            //
+            CBUseHDR.AutoSize = true;
+            CBUseHDR.Location = new Point(6, 134);
+            CBUseHDR.Name = "CBUseHDR";
+            CBUseHDR.Size = new Size(72, 19);
+            CBUseHDR.TabIndex = 11;
+            CBUseHDR.Text = "Enable HDR Support";
+            CBUseHDR.UseVisualStyleBackColor = true;
+            //
+            // InputAffinityNum
+            //
+            InputAffinityNum.Location = new Point(128, 107);
+            InputAffinityNum.Name = "InputAffinityNum";
+            InputAffinityNum.Size = new Size(121, 23);
+            InputAffinityNum.TabIndex = 10;
+            InputAffinityNum.Maximum = new decimal(new int[] { int.MaxValue, 0, 0, 0 });
+            InputAffinityNum.Minimum = new decimal(new int[] { 0, 0, 0, 0 });
+            InputAffinityNum.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            //
+            // LabelAffinity
+            //
+            LabelAffinity.AutoSize = true;
+            LabelAffinity.Location = new Point(3, 109);
+            LabelAffinity.Name = "LabelAffinity";
+            LabelAffinity.Size = new Size(52, 15);
+            LabelAffinity.TabIndex = 9;
+            LabelAffinity.Text = "Affinity: ";
+            //
             // TabLaunchOptions
-            // 
+            //
             TabLaunchOptions.Controls.Add(CBUseMobileUI);
             TabLaunchOptions.Controls.Add(InputMonitorNum);
             TabLaunchOptions.Controls.Add(LabelMonitor);
@@ -176,9 +212,9 @@
             TabLaunchOptions.TabIndex = 1;
             TabLaunchOptions.Text = "Launch Options";
             TabLaunchOptions.UseVisualStyleBackColor = true;
-            // 
+            //
             // CBUseMobileUI
-            // 
+            //
             CBUseMobileUI.AutoSize = true;
             CBUseMobileUI.Location = new Point(6, 81);
             CBUseMobileUI.Name = "CBUseMobileUI";
@@ -186,27 +222,27 @@
             CBUseMobileUI.TabIndex = 11;
             CBUseMobileUI.Text = "Use Mobile UI";
             CBUseMobileUI.UseVisualStyleBackColor = true;
-            // 
+            //
             // InputMonitorNum
-            // 
+            //
             InputMonitorNum.Location = new Point(111, 168);
             InputMonitorNum.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
             InputMonitorNum.Name = "InputMonitorNum";
             InputMonitorNum.Size = new Size(135, 23);
             InputMonitorNum.TabIndex = 10;
             InputMonitorNum.Value = new decimal(new int[] { 1, 0, 0, 0 });
-            // 
+            //
             // LabelMonitor
-            // 
+            //
             LabelMonitor.AutoSize = true;
             LabelMonitor.Location = new Point(6, 170);
             LabelMonitor.Name = "LabelMonitor";
             LabelMonitor.Size = new Size(56, 15);
             LabelMonitor.TabIndex = 9;
             LabelMonitor.Text = "Monitor: ";
-            // 
+            //
             // ComboFullscreenMode
-            // 
+            //
             ComboFullscreenMode.FormattingEnabled = true;
             ComboFullscreenMode.Items.AddRange(new object[] { "Borderless", "Exclusive" });
             ComboFullscreenMode.Location = new Point(111, 139);
@@ -214,18 +250,18 @@
             ComboFullscreenMode.Size = new Size(135, 23);
             ComboFullscreenMode.TabIndex = 8;
             ComboFullscreenMode.Text = "Borderless";
-            // 
+            //
             // LabelWindowMode
-            // 
+            //
             LabelWindowMode.AutoSize = true;
             LabelWindowMode.Location = new Point(6, 142);
             LabelWindowMode.Name = "LabelWindowMode";
             LabelWindowMode.Size = new Size(97, 15);
             LabelWindowMode.TabIndex = 7;
             LabelWindowMode.Text = "Fullscreen Mode:";
-            // 
+            //
             // InputResY
-            // 
+            //
             InputResY.Location = new Point(191, 110);
             InputResY.Maximum = new decimal(new int[] { 4320, 0, 0, 0 });
             InputResY.Minimum = new decimal(new int[] { 200, 0, 0, 0 });
@@ -233,18 +269,18 @@
             InputResY.Size = new Size(55, 23);
             InputResY.TabIndex = 6;
             InputResY.Value = new decimal(new int[] { 1080, 0, 0, 0 });
-            // 
+            //
             // LabelX
-            // 
+            //
             LabelX.AutoSize = true;
             LabelX.Location = new Point(172, 112);
             LabelX.Name = "LabelX";
             LabelX.Size = new Size(13, 15);
             LabelX.TabIndex = 5;
             LabelX.Text = "x";
-            // 
+            //
             // InputResX
-            // 
+            //
             InputResX.Location = new Point(111, 110);
             InputResX.Maximum = new decimal(new int[] { 7680, 0, 0, 0 });
             InputResX.Minimum = new decimal(new int[] { 200, 0, 0, 0 });
@@ -252,18 +288,18 @@
             InputResX.Size = new Size(55, 23);
             InputResX.TabIndex = 4;
             InputResX.Value = new decimal(new int[] { 1920, 0, 0, 0 });
-            // 
+            //
             // LabelCustomRes
-            // 
+            //
             LabelCustomRes.AutoSize = true;
             LabelCustomRes.Location = new Point(6, 112);
             LabelCustomRes.Name = "LabelCustomRes";
             LabelCustomRes.Size = new Size(69, 15);
             LabelCustomRes.TabIndex = 3;
             LabelCustomRes.Text = "Resolution: ";
-            // 
+            //
             // CBCustomRes
-            // 
+            //
             CBCustomRes.AutoSize = true;
             CBCustomRes.Location = new Point(6, 56);
             CBCustomRes.Name = "CBCustomRes";
@@ -272,9 +308,9 @@
             CBCustomRes.Text = "Custom Resolution";
             CBCustomRes.UseVisualStyleBackColor = true;
             CBCustomRes.CheckStateChanged += LaunchOptionsChanged;
-            // 
+            //
             // CBFullscreen
-            // 
+            //
             CBFullscreen.AutoSize = true;
             CBFullscreen.Location = new Point(6, 31);
             CBFullscreen.Name = "CBFullscreen";
@@ -283,9 +319,9 @@
             CBFullscreen.Text = "Fullscreen";
             CBFullscreen.UseVisualStyleBackColor = true;
             CBFullscreen.CheckStateChanged += LaunchOptionsChanged;
-            // 
+            //
             // CBPopup
-            // 
+            //
             CBPopup.AutoSize = true;
             CBPopup.Location = new Point(6, 6);
             CBPopup.Name = "CBPopup";
@@ -294,9 +330,9 @@
             CBPopup.Text = "Borderless Window";
             CBPopup.UseVisualStyleBackColor = true;
             CBPopup.CheckStateChanged += LaunchOptionsChanged;
-            // 
+            //
             // TabDlls
-            // 
+            //
             TabDlls.Controls.Add(CBSuspendLoad);
             TabDlls.Controls.Add(BtnRemoveDll);
             TabDlls.Controls.Add(BtnAddDll);
@@ -309,9 +345,9 @@
             TabDlls.TabIndex = 2;
             TabDlls.Text = "DLLs";
             TabDlls.UseVisualStyleBackColor = true;
-            // 
+            //
             // CBSuspendLoad
-            // 
+            //
             CBSuspendLoad.AutoSize = true;
             CBSuspendLoad.Location = new Point(138, 79);
             CBSuspendLoad.Name = "CBSuspendLoad";
@@ -320,9 +356,9 @@
             CBSuspendLoad.Text = "Suspend Load";
             ToolTipSettings.SetToolTip(CBSuspendLoad, "This can ensure dll gets loaded before the game starts\r\nIt may not work all the times\r\nUncheck this if the game crashes");
             CBSuspendLoad.UseVisualStyleBackColor = true;
-            // 
+            //
             // BtnRemoveDll
-            // 
+            //
             BtnRemoveDll.Location = new Point(132, 50);
             BtnRemoveDll.Name = "BtnRemoveDll";
             BtnRemoveDll.Size = new Size(114, 23);
@@ -330,9 +366,9 @@
             BtnRemoveDll.Text = "Remove";
             BtnRemoveDll.UseVisualStyleBackColor = true;
             BtnRemoveDll.Click += BtnRemoveDll_Click;
-            // 
+            //
             // BtnAddDll
-            // 
+            //
             BtnAddDll.Location = new Point(132, 21);
             BtnAddDll.Name = "BtnAddDll";
             BtnAddDll.Size = new Size(114, 23);
@@ -340,9 +376,9 @@
             BtnAddDll.Text = "Add";
             BtnAddDll.UseVisualStyleBackColor = true;
             BtnAddDll.Click += BtnAddDll_Click;
-            // 
+            //
             // ListBoxDlls
-            // 
+            //
             ListBoxDlls.FormattingEnabled = true;
             ListBoxDlls.ItemHeight = 15;
             ListBoxDlls.Location = new Point(6, 21);
@@ -351,30 +387,30 @@
             ListBoxDlls.TabIndex = 1;
             ListBoxDlls.Format += ListBoxDlls_Format;
             ListBoxDlls.MouseMove += ListBoxDlls_MouseMove;
-            // 
+            //
             // label1
-            // 
+            //
             label1.AutoSize = true;
             label1.Location = new Point(6, 3);
             label1.Name = "label1";
             label1.Size = new Size(232, 15);
             label1.TabIndex = 0;
             label1.Text = "DLLs will be injected in the order of this list";
-            // 
+            //
             // ToolTipSettings
-            // 
+            //
             ToolTipSettings.AutoPopDelay = 5000;
             ToolTipSettings.InitialDelay = 500;
             ToolTipSettings.ReshowDelay = 500;
-            // 
+            //
             // DllAddDialog
-            // 
+            //
             DllAddDialog.Filter = "DLL (*.dll)|*.dll|All files (*.*)|*.*";
             DllAddDialog.Multiselect = true;
             DllAddDialog.RestoreDirectory = true;
-            // 
+            //
             // SettingsForm
-            // 
+            //
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(284, 261);
@@ -393,6 +429,7 @@
             TabGeneral.PerformLayout();
             TabLaunchOptions.ResumeLayout(false);
             TabLaunchOptions.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)InputAffinityNum).EndInit();
             ((System.ComponentModel.ISupportInitialize)InputMonitorNum).EndInit();
             ((System.ComponentModel.ISupportInitialize)InputResY).EndInit();
             ((System.ComponentModel.ISupportInitialize)InputResX).EndInit();
@@ -423,6 +460,8 @@
         private CheckBox CBPopup;
         private NumericUpDown InputMonitorNum;
         private Label LabelMonitor;
+        private NumericUpDown InputAffinityNum;
+        private Label LabelAffinity;
         private ComboBox ComboFullscreenMode;
         private Label LabelWindowMode;
         private Label label1;
@@ -432,6 +471,7 @@
         private ToolTip ToolTipSettings;
         private CheckBox CBSuspendLoad;
         private CheckBox CBUseMobileUI;
+        private CheckBox CBUseHDR;
         private OpenFileDialog DllAddDialog;
     }
 }

--- a/unlockfps_nc/SettingsForm.cs
+++ b/unlockfps_nc/SettingsForm.cs
@@ -38,7 +38,9 @@ namespace unlockfps_nc
             CBAutoClose.DataBindings.Add("Checked", _config, "AutoClose", true, DataSourceUpdateMode.OnPropertyChanged);
             CBPowerSave.DataBindings.Add("Checked", _config, "UsePowerSave", true, DataSourceUpdateMode.OnPropertyChanged);
             ComboPriority.DataBindings.Add("SelectedIndex", _config, "Priority", true, DataSourceUpdateMode.OnPropertyChanged);
-            
+            CBUseHDR.DataBindings.Add("Checked", _config, "UseHDR", true, DataSourceUpdateMode.OnPropertyChanged);
+            InputAffinityNum.DataBindings.Add("Value", _config, "Affinity", true, DataSourceUpdateMode.OnPropertyChanged);
+
             // Launch Options
             CBPopup.DataBindings.Add("Checked", _config, "PopupWindow", true, DataSourceUpdateMode.OnPropertyChanged);
             CBFullscreen.DataBindings.Add("Checked", _config, "Fullscreen", true, DataSourceUpdateMode.OnPropertyChanged);
@@ -50,7 +52,7 @@ namespace unlockfps_nc
             InputMonitorNum.DataBindings.Add("Value", _config, "MonitorNum", true, DataSourceUpdateMode.OnPropertyChanged);
 
 #if !RELEASEMIN
-            // DLLs            
+            // DLLs
             RefreshDllList();
             CBSuspendLoad.DataBindings.Add("Checked", _config, "SuspendLoad", true, DataSourceUpdateMode.OnPropertyChanged);
 #endif
@@ -97,7 +99,7 @@ namespace unlockfps_nc
         {
             if (DllAddDialog.ShowDialog() != DialogResult.OK)
                 return;
-            
+
             var selectedFiles = DllAddDialog.FileNames.ToList();
             selectedFiles = selectedFiles
                 .Where(x => VerifyDll(x) || MessageBox.Show(
@@ -144,7 +146,7 @@ namespace unlockfps_nc
             var selectedIndex = ListBoxDlls.SelectedIndex;
             if (selectedIndex == -1)
                 return;
-            
+
             _config.DllList.RemoveAt(selectedIndex);
             RefreshDllList();
         }


### PR DESCRIPTION
Hello, this PR adds support for the official HDR registry key as well as processor affinity.

## HDR support
The HDR registry key (WINDOWS_HDR_ON_h3132281285) is set to 1 on launch if the checkbox in the settings is checked and is done at every launch because the game will reset it to 0 when it starts.

## Processor affinity
The processor affinity setting allows you to select which cores the game should run on and unfortunately, is a requirement if you want to play the game on a defective 13th and 14th gen Intel CPU.
- The setting defaults to 0, which completely disable any kind of affinity customisation.
- A setting of 255 would represent a value of 0b11111111 which would limit the game to running on the first 

This issue is quite common, but for reference: https://github.com/34736384/genshin-fps-unlock/issues/454#issuecomment-2314655136

This feature is the equivalent of opening task manager and changing the affinity there:
![image](https://github.com/user-attachments/assets/7d2723c4-767f-49dd-8d5a-b5735a83a095)

## Screenshots of the changes
![image](https://github.com/user-attachments/assets/91da4989-e947-4d72-98b7-2bb894a1ca93)
