### PR TITLE
feat: remember monitor name instead of number

### DIFF
--- a/unlockfps_nc/Model/Config.cs
+++ b/unlockfps_nc/Model/Config.cs
@@ -25,7 +25,7 @@ namespace unlockfps_nc.Model
         public int FPSTarget { get; set; } = 120;
         public int CustomResX { get; set; } = 1920;
         public int CustomResY { get; set; } = 1080;
-        public int MonitorNum { get; set; } = 1;
+        public string MonitorName { get; set; } = "";
         public int Priority { get; set; } = 3;
         public string AdditionalCommandLine { get; set; } = "";
 

--- a/unlockfps_nc/Service/ConfigService.cs
+++ b/unlockfps_nc/Service/ConfigService.cs
@@ -42,7 +42,6 @@ namespace unlockfps_nc.Service
             Config.Priority = Math.Clamp(Config.Priority, 0, 5);
             Config.CustomResX = Math.Clamp(Config.CustomResX, 200, 7680);
             Config.CustomResY = Math.Clamp(Config.CustomResY, 200, 4320);
-            Config.MonitorNum = Math.Clamp(Config.MonitorNum, 1, 100);
         }
 
         private string GetFullPath()

--- a/unlockfps_nc/Service/ProcessService.cs
+++ b/unlockfps_nc/Service/ProcessService.cs
@@ -159,7 +159,7 @@ namespace unlockfps_nc.Service
 
             if (_config.MonitorName != "")
             {
-                var displayDeviceKeyToFriendlyNameDict = WindowsDisplayAPI.DisplayConfig.PathDisplayTarget.GetDisplayTargets().ToDictionary(d => d.ToDisplayDevice().DeviceKey, d => d.FriendlyName);
+                var displayDeviceKeyToFriendlyNameDict = WindowsDisplayAPI.DisplayConfig.PathDisplayTarget.GetDisplayTargets().Where(d => d.ToDisplayDevice() != null).ToDictionary(d => d.ToDisplayDevice().DeviceKey, d => d.FriendlyName);
                 var availableDisplays = WindowsDisplayAPI.Display.GetDisplays().Where(d => d.IsAvailable).ToList();
                 availableDisplays.Sort((a, b) => a.SavedSetting.Position.IsEmpty ? -1 : b.SavedSetting.Position.IsEmpty ? 1 : a.SavedSetting.Position.X.CompareTo(b.SavedSetting.Position.X));
                 for (int i = 0; i < availableDisplays.Count; i++)

--- a/unlockfps_nc/Service/ProcessService.cs
+++ b/unlockfps_nc/Service/ProcessService.cs
@@ -32,29 +32,35 @@ namespace unlockfps_nc.Service
 
         public bool StartGame()
         {
-            if (!File.Exists(_config.GamePath)) {
+            if (!File.Exists(_config.GamePath))
+            {
                 MessageBox.Show(@"Game path is invalid.", @"Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 
-            if (IsGameRunning()) {
+            if (IsGameRunning())
+            {
                 MessageBox.Show(@"An instance of the game is already running.", @"Error", MessageBoxButtons.OK,
                     MessageBoxIcon.Error);
                 return false;
             }
 
-            if (_gameHandle != IntPtr.Zero) {
+            if (_gameHandle != IntPtr.Zero)
+            {
                 Native.CloseHandle(_gameHandle);
                 _gameHandle = IntPtr.Zero;
             }
 
-            if (_config.UseHDR) {
+            if (_config.UseHDR)
+            {
                 var subKeyName = Path.GetFileName(_config.GamePath) == "YuanShen.exe" ? "原神" : "Genshin Impact";
-                try {
+                try
+                {
                     using var key = Registry.CurrentUser.CreateSubKey($@"Software\miHoYo\{subKeyName}");
                     key.SetValue("WINDOWS_HDR_ON_h3132281285", 1);
                 }
-                catch(Exception e) {
+                catch (Exception e)
+                {
                     MessageBox.Show($@"Failed to enable HDR: {e.Message}", @"Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
@@ -63,14 +69,16 @@ namespace unlockfps_nc.Service
             uint creationFlag = _config.SuspendLoad ? 4u : 0u;
             var gameFolder = Path.GetDirectoryName(_config.GamePath);
 
-            if (!Native.CreateProcess(_config.GamePath, BuildCommandLine(), IntPtr.Zero, IntPtr.Zero, false, creationFlag, IntPtr.Zero, gameFolder, ref si, out var pi)) {
+            if (!Native.CreateProcess(_config.GamePath, BuildCommandLine(), IntPtr.Zero, IntPtr.Zero, false, creationFlag, IntPtr.Zero, gameFolder, ref si, out var pi))
+            {
                 MessageBox.Show(
                     $@"CreateProcess failed ({Marshal.GetLastWin32Error()}){Environment.NewLine} {Marshal.GetLastPInvokeErrorMessage()}",
                     @"Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 
-            if (!ProcessUtils.InjectDlls(pi.hProcess, _config.DllList)) {
+            if (!ProcessUtils.InjectDlls(pi.hProcess, _config.DllList))
+            {
                 MessageBox.Show(
                     $@"Dll Injection failed ({Marshal.GetLastWin32Error()}){Environment.NewLine} {Marshal.GetLastPInvokeErrorMessage()}",
                     @"Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -105,7 +113,8 @@ namespace unlockfps_nc.Service
 
         private async Task UnlockerPoll()
         {
-            while (!_cts.IsCancellationRequested) {
+            while (!_cts.IsCancellationRequested)
+            {
 
                 await Task.Delay(1000, _cts.Token);
                 using var process = Process.GetProcesses()
@@ -119,12 +128,14 @@ namespace unlockfps_nc.Service
                 if (!_ipcService.Start(process.Id))
                     return;
 
-                while (!process.HasExited && !_cts.IsCancellationRequested) {
+                while (!process.HasExited && !_cts.IsCancellationRequested)
+                {
                     _ipcService.Update();
                     await Task.Delay(62, _cts.Token);
                 }
 
-                if (_gameHandle != IntPtr.Zero && _config.AutoClose) {
+                if (_gameHandle != IntPtr.Zero && _config.AutoClose)
+                {
                     Application.Exit();
                 }
 
@@ -146,7 +157,22 @@ namespace unlockfps_nc.Service
             if (_config.Fullscreen)
                 commandLine += $"-window-mode {(_config.IsExclusiveFullscreen ? "exclusive" : "borderless")} ";
 
-            commandLine += $"-monitor {_config.MonitorNum} ";
+            if (_config.MonitorName != "")
+            {
+                var displayDeviceKeyToFriendlyNameDict = WindowsDisplayAPI.DisplayConfig.PathDisplayTarget.GetDisplayTargets().ToDictionary(d => d.ToDisplayDevice().DeviceKey, d => d.FriendlyName);
+                var availableDisplays = WindowsDisplayAPI.Display.GetDisplays().Where(d => d.IsAvailable).ToList();
+                availableDisplays.Sort((a, b) => a.SavedSetting.Position.IsEmpty ? -1 : b.SavedSetting.Position.IsEmpty ? 1 : a.SavedSetting.Position.X.CompareTo(b.SavedSetting.Position.X));
+                for (int i = 0; i < availableDisplays.Count; i++)
+                {
+                    var display = availableDisplays[i];
+                    if (displayDeviceKeyToFriendlyNameDict.ContainsKey(display.DeviceKey) && displayDeviceKeyToFriendlyNameDict[display.DeviceKey] == _config.MonitorName)
+                    {
+                        commandLine += $"-monitor {i + 1} ";
+                        break;
+                    }
+                }
+            }
+
             commandLine += $"{_config.AdditionalCommandLine} ";
             return commandLine;
         }

--- a/unlockfps_nc/SettingsForm.Designer.cs
+++ b/unlockfps_nc/SettingsForm.Designer.cs
@@ -39,7 +39,7 @@
             CBStartMinimized = new CheckBox();
             TabLaunchOptions = new TabPage();
             CBUseMobileUI = new CheckBox();
-            InputMonitorNum = new NumericUpDown();
+            ComboInputMonitor = new ComboBox();
             LabelMonitor = new Label();
             ComboFullscreenMode = new ComboBox();
             LabelWindowMode = new Label();
@@ -62,7 +62,6 @@
             TabCtrlSettings.SuspendLayout();
             TabGeneral.SuspendLayout();
             TabLaunchOptions.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)InputMonitorNum).BeginInit();
             ((System.ComponentModel.ISupportInitialize)InputResY).BeginInit();
             ((System.ComponentModel.ISupportInitialize)InputResX).BeginInit();
             TabDlls.SuspendLayout();
@@ -160,7 +159,7 @@
             // TabLaunchOptions
             // 
             TabLaunchOptions.Controls.Add(CBUseMobileUI);
-            TabLaunchOptions.Controls.Add(InputMonitorNum);
+            TabLaunchOptions.Controls.Add(ComboInputMonitor);
             TabLaunchOptions.Controls.Add(LabelMonitor);
             TabLaunchOptions.Controls.Add(ComboFullscreenMode);
             TabLaunchOptions.Controls.Add(LabelWindowMode);
@@ -191,12 +190,11 @@
             // 
             // InputMonitorNum
             // 
-            InputMonitorNum.Location = new Point(111, 168);
-            InputMonitorNum.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
-            InputMonitorNum.Name = "InputMonitorNum";
-            InputMonitorNum.Size = new Size(135, 23);
-            InputMonitorNum.TabIndex = 10;
-            InputMonitorNum.Value = new decimal(new int[] { 1, 0, 0, 0 });
+            ComboInputMonitor.Location = new Point(111, 168);
+            ComboInputMonitor.Name = "InputMonitorNum";
+            ComboInputMonitor.Size = new Size(135, 23);
+            ComboInputMonitor.TabIndex = 10;
+            ComboInputMonitor.Items.AddRange(WindowsDisplayAPI.DisplayConfig.PathDisplayTarget.GetDisplayTargets().Select(d => d.FriendlyName).ToArray());
             // 
             // LabelMonitor
             // 
@@ -405,7 +403,6 @@
             TabGeneral.PerformLayout();
             TabLaunchOptions.ResumeLayout(false);
             TabLaunchOptions.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)InputMonitorNum).EndInit();
             ((System.ComponentModel.ISupportInitialize)InputResY).EndInit();
             ((System.ComponentModel.ISupportInitialize)InputResX).EndInit();
             TabDlls.ResumeLayout(false);
@@ -433,7 +430,7 @@
         private CheckBox CBCustomRes;
         private CheckBox CBFullscreen;
         private CheckBox CBPopup;
-        private NumericUpDown InputMonitorNum;
+        private ComboBox ComboInputMonitor;
         private Label LabelMonitor;
         private ComboBox ComboFullscreenMode;
         private Label LabelWindowMode;

--- a/unlockfps_nc/SettingsForm.cs
+++ b/unlockfps_nc/SettingsForm.cs
@@ -48,7 +48,7 @@ namespace unlockfps_nc
             InputResX.DataBindings.Add("Value", _config, "CustomResX", true, DataSourceUpdateMode.OnPropertyChanged);
             InputResY.DataBindings.Add("Value", _config, "CustomResY", true, DataSourceUpdateMode.OnPropertyChanged);
             ComboFullscreenMode.DataBindings.Add("SelectedIndex", _config, "IsExclusiveFullscreen", true, DataSourceUpdateMode.OnPropertyChanged);
-            InputMonitorNum.DataBindings.Add("Value", _config, "MonitorNum", true, DataSourceUpdateMode.OnPropertyChanged);
+            ComboInputMonitor.DataBindings.Add("Text", _config, "MonitorName", true, DataSourceUpdateMode.OnPropertyChanged);
 
 #if !RELEASEMIN
             // DLLs            

--- a/unlockfps_nc/unlockfps_nc.csproj
+++ b/unlockfps_nc/unlockfps_nc.csproj
@@ -43,6 +43,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="WindowsDisplayAPI" Version="1.3.0.13" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
this prevents a mismatch when the monitor number changes. for example when main display is switched around in a multi-display set up

![devenv_2AJaqI23Hh](https://github.com/user-attachments/assets/4abd1cec-fab6-4b9c-b683-b605719d5aea)

just an idea