### PR TITLE
Bring existing instance to foreground instead of showing error

### DIFF
--- a/unlockfps_nc/MainForm.cs
+++ b/unlockfps_nc/MainForm.cs
@@ -109,5 +109,29 @@ namespace unlockfps_nc
             var aboutForm = new AboutForm();
             aboutForm.ShowDialog();
         }
+
+        public void BringToForeground()
+        {
+            if (InvokeRequired)
+            {
+                Invoke(new Action(BringToForeground));
+                return;
+            }
+
+            if (WindowState == FormWindowState.Minimized)
+            {
+                WindowState = FormWindowState.Normal;
+                ShowInTaskbar = true;
+                Show();
+            }
+
+            TopMost = true;
+            Activate();
+            BringToFront();
+            TopMost = false;
+
+            Location = _windowLocation;
+            Size = _windowSize;
+        }
     }
 }

--- a/unlockfps_nc/Program.cs
+++ b/unlockfps_nc/Program.cs
@@ -22,7 +22,7 @@ namespace unlockfps_nc
             MutexHandle = Native.CreateMutex(IntPtr.Zero, true, @"GenshinFPSUnlocker");
             if (Marshal.GetLastWin32Error() == 183)
             {
-                MessageBox.Show(@"Another unlocker is already running.", @"Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                ActivationService.TryActivateExistingInstance();
                 return;
             }
             
@@ -37,7 +37,12 @@ namespace unlockfps_nc
             ServiceProvider = services.BuildServiceProvider();
 
             ApplicationConfiguration.Initialize();
-            Application.Run(ServiceProvider.GetRequiredService<MainForm>());
+            
+            var mainForm = ServiceProvider.GetRequiredService<MainForm>();
+            var activationService = new ActivationService(mainForm);
+            activationService.StartListening();
+            
+            Application.Run(mainForm);
         }
 
 

--- a/unlockfps_nc/Service/ActivationService.cs
+++ b/unlockfps_nc/Service/ActivationService.cs
@@ -1,0 +1,65 @@
+using System.IO.Pipes;
+
+namespace unlockfps_nc.Service
+{
+    public class ActivationService : IDisposable
+    {
+        private NamedPipeServerStream? _pipeServer;
+        private CancellationTokenSource _cancellationTokenSource = new();
+        private readonly MainForm _mainForm;
+
+        public ActivationService(MainForm mainForm)
+        {
+            _mainForm = mainForm;
+        }
+
+        public void StartListening()
+        {
+            Task.Run(async () =>
+            {
+                while (!_cancellationTokenSource.Token.IsCancellationRequested)
+                {
+                    try
+                    {
+                        _pipeServer = new NamedPipeServerStream("GenshinFPSUnlockerActivation", PipeDirection.In, 1);
+                        await _pipeServer.WaitForConnectionAsync(_cancellationTokenSource.Token);
+                        
+                        _mainForm.BringToForeground();
+                        
+                        _pipeServer.Disconnect();
+                        _pipeServer.Dispose();
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        break;
+                    }
+                    catch (Exception)
+                    {
+                        // Ignore pipe exceptions and continue listening
+                    }
+                }
+            });
+        }
+
+        public static bool TryActivateExistingInstance()
+        {
+            try
+            {
+                using var pipeClient = new NamedPipeClientStream(".", "GenshinFPSUnlockerActivation", PipeDirection.Out);
+                pipeClient.Connect(1000); // 1 second timeout
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public void Dispose()
+        {
+            _cancellationTokenSource.Cancel();
+            _pipeServer?.Dispose();
+            _cancellationTokenSource.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
When launching a second instance, the application now activates the existing window from the system tray instead of displaying an error message. This improves user experience by providing seamless window management.

Fixes #522