### PR TITLE
Respond to Xbox Controller input on MainPage

### DIFF
--- a/unlockfps_nc/MainForm.Designer.cs
+++ b/unlockfps_nc/MainForm.Designer.cs
@@ -188,6 +188,8 @@
             Name = "MainForm";
             StartPosition = FormStartPosition.CenterScreen;
             Text = "Genshin FPS Unlocker";
+            Activated += MainForm_Activated;
+            Deactivate += MainForm_Deactivate;
             FormClosing += MainForm_FormClosing;
             Load += MainForm_Load;
             Resize += MainForm_Resize;

--- a/unlockfps_nc/MainForm.cs
+++ b/unlockfps_nc/MainForm.cs
@@ -14,18 +14,31 @@ namespace unlockfps_nc
         private readonly ConfigService _configService;
         private readonly Config _config;
         private readonly ProcessService _processService;
+        private readonly MainPageXInputService _mainPageXInputService;
 
         private bool _notifyOnce = false;
 
         public MainForm(
             ConfigService configService,
-            ProcessService processService)
+            ProcessService processService,
+            MainPageXInputService mainPageXInputService)
         {
             InitializeComponent();
             _configService = configService;
             _config = _configService.Config;
             _processService = processService;
+            _mainPageXInputService = mainPageXInputService;
+            mainPageXInputService.KeyBPressed += (s, e) => NotifyAndHide();
+            mainPageXInputService.KeyYPressed += BtnStartGame_Click;
+            mainPageXInputService.KeyLCenterPressed += (s, e) => CBAutoStart.Checked = !CBAutoStart.Checked;
+            mainPageXInputService.FpsAdjustPressed += FpsAdjustPressed;
             SetupBindings();
+        }
+
+        private void FpsAdjustPressed(object? sender, int delta)
+        {
+            var newFps = Math.Clamp(SliderFPS.Value + delta, SliderFPS.Minimum, SliderFPS.Maximum);
+            SliderFPS.Value = newFps;
         }
 
         private void SettingsMenuItem_Click(object sender, EventArgs e)
@@ -63,7 +76,7 @@ namespace unlockfps_nc
             ShowSetupForm();
         }
 
-        private void BtnStartGame_Click(object sender, EventArgs e)
+        private void BtnStartGame_Click(object? sender, EventArgs? e)
         {
             if (!File.Exists(_config.GamePath))
                 ShowSetupForm();
@@ -91,7 +104,8 @@ namespace unlockfps_nc
 
         private void NotifyAndHide()
         {
-            if (!_notifyOnce) {
+            if (!_notifyOnce)
+            {
                 NotifyIconMain.Visible = true;
                 NotifyIconMain.Text = $@"FPS Unlocker (FPS: {_config.FPSTarget})";
                 NotifyIconMain.ShowBalloonTip(500);
@@ -120,7 +134,8 @@ namespace unlockfps_nc
 
         public void RestoreFromTray()
         {
-            if (InvokeRequired) {
+            if (InvokeRequired)
+            {
                 Invoke(RestoreFromTray);
                 return;
             }
@@ -131,7 +146,7 @@ namespace unlockfps_nc
             Show();
             Activate();
             TopMost = false;
-            
+
             Location = _windowLocation;
             Size = _windowSize;
         }
@@ -146,7 +161,7 @@ namespace unlockfps_nc
                 response.EnsureSuccessStatusCode();
                 var content = await response.Content.ReadAsStringAsync();
                 var remoteVersion = JsonSerializer.Deserialize<VersionInfo>(content);
-                
+
                 if (remoteVersion == null || remoteVersion.Version <= Program.Version)
                     return;
 
@@ -162,8 +177,9 @@ namespace unlockfps_nc
 
                 var result = MessageBox.Show(message, @"FPS Unlocker", MessageBoxButtons.YesNo, MessageBoxIcon.Information, MessageBoxDefaultButton.Button1,
                     MessageBoxOptions.DefaultDesktopOnly);
-                
-                if (result == DialogResult.Yes) {
+
+                if (result == DialogResult.Yes)
+                {
                     var psi = new ProcessStartInfo
                     {
                         FileName = remoteVersion.Url,
@@ -171,7 +187,8 @@ namespace unlockfps_nc
                     };
                     Process.Start(psi);
                 }
-                else {
+                else
+                {
                     _config.LastVersionNotify = utcNow.ToUnixTimeSeconds();
                     _configService.Save();
                 }
@@ -184,5 +201,14 @@ namespace unlockfps_nc
 
         }
 
+        private void MainForm_Activated(object sender, EventArgs e)
+        {
+            _mainPageXInputService.ResumeListening();
+        }
+
+        private void MainForm_Deactivate(object sender, EventArgs e)
+        {
+            _mainPageXInputService.PauseListening();
+        }
     }
 }

--- a/unlockfps_nc/Program.cs
+++ b/unlockfps_nc/Program.cs
@@ -74,6 +74,7 @@ namespace unlockfps_nc
             services.AddSingleton<ConfigService>();
             services.AddSingleton<ProcessService>();
             services.AddSingleton<IpcService>();
+            services.AddSingleton<MainPageXInputService>();
 
             ServiceProvider = services.BuildServiceProvider();
 

--- a/unlockfps_nc/Service/MainPageXInputService.cs
+++ b/unlockfps_nc/Service/MainPageXInputService.cs
@@ -1,0 +1,147 @@
+﻿using unlockfps_nc.Utility;
+
+namespace unlockfps_nc.Service;
+
+public sealed class MainPageXInputService
+{
+    private enum InputState
+    {
+        Standby,
+        FpsAdjustSlow,
+        FpsAdjustFast,
+    }
+    private const int SCAN_DELAY_NOT_CONNECTED = 3000;
+    private const int SCAN_DELAY_NORMAL_KEY = 100;
+    private const int SCAN_DELAY_FPS_ADJUST_SLOW = 100;
+    private const int SCAN_DELAY_FPS_ADJUST_FAST = 1;
+    private const int FPS_ADJUST_FAST_STEPIN = 1;
+    private const int FPS_ADJUST_SLOW_COUNT_THRESHOLD = 10;
+    private void StartLoop(SynchronizationContext syncCtx, CancellationToken cancellationToken)
+    {
+        Task.Run(async () =>
+        {
+            var inputState = InputState.Standby;
+            int fpsSlowCount = 0, fpsDirection = 1;
+            do
+            {
+                try
+                {
+                    var keystrokeRes = Native.XInputGetKeystroke(XUserIndex.XUSER_INDEX_ANY, 0, out var keystroke);
+                    if (keystrokeRes == XInputGetKeystrokeResult.ERROR_DEVICE_NOT_CONNECTED)
+                    {
+                        await Task.Delay(SCAN_DELAY_NOT_CONNECTED, cancellationToken);
+                        continue;
+                    }
+                    int delay;
+                    var isTrigger = keystroke.VirtualKey is XKeystrokeCode.VK_PAD_LTRIGGER or XKeystrokeCode.VK_PAD_RTRIGGER;
+                    var isKeyDown = (keystroke.Flags & XKeystrokeFlags.XINPUT_KEYSTROKE_KEYDOWN) != 0;
+                    var isKeyUp = (keystroke.Flags & XKeystrokeFlags.XINPUT_KEYSTROKE_KEYUP) != 0;
+                    var isKeyRepeat = (keystroke.Flags & XKeystrokeFlags.XINPUT_KEYSTROKE_REPEAT) != 0;
+                    switch ((inputState, isKeyDown, isKeyUp))
+                    {
+                        case (InputState.Standby, true, _) when !isKeyRepeat:
+                            {
+                                fpsSlowCount = 0;
+                                switch (keystroke.VirtualKey)
+                                {
+                                    case XKeystrokeCode.VK_PAD_B:
+                                        syncCtx.Post(_ => KeyBPressed?.Invoke(this, EventArgs.Empty), null);
+                                        delay = SCAN_DELAY_NORMAL_KEY;
+                                        break;
+                                    case XKeystrokeCode.VK_PAD_Y:
+                                        syncCtx.Post(_ => KeyYPressed?.Invoke(this, EventArgs.Empty), null);
+                                        delay = SCAN_DELAY_NORMAL_KEY;
+                                        break;
+                                    case XKeystrokeCode.VK_PAD_LTHUMB_PRESS:
+                                        syncCtx.Post(_ => KeyLCenterPressed?.Invoke(this, EventArgs.Empty), null);
+                                        delay = SCAN_DELAY_NORMAL_KEY;
+                                        break;
+                                    case XKeystrokeCode.VK_PAD_LTRIGGER:
+                                        syncCtx.Post(_ => FpsAdjustPressed?.Invoke(this, -1), null);
+                                        delay = SCAN_DELAY_FPS_ADJUST_SLOW;
+                                        inputState = InputState.FpsAdjustSlow;
+                                        fpsDirection = -1;
+                                        break;
+                                    case XKeystrokeCode.VK_PAD_RTRIGGER:
+                                        syncCtx.Post(_ => FpsAdjustPressed?.Invoke(this, 1), null);
+                                        delay = SCAN_DELAY_FPS_ADJUST_SLOW;
+                                        inputState = InputState.FpsAdjustSlow;
+                                        fpsDirection = 1;
+                                        break;
+                                    default:
+                                        delay = SCAN_DELAY_NORMAL_KEY;
+                                        break;
+                                }
+                                break;
+                            }
+                        case (InputState.FpsAdjustSlow or InputState.FpsAdjustFast, _, true):
+                        case (InputState.FpsAdjustSlow or InputState.FpsAdjustFast, true, _) when !isTrigger:
+                            {
+                                delay = SCAN_DELAY_NORMAL_KEY;
+                                inputState = InputState.Standby;
+                            }
+                            break;
+                        case (InputState.FpsAdjustSlow, _, false):
+                            {
+                                syncCtx.Post(_ => FpsAdjustPressed?.Invoke(this, fpsDirection), null);
+                                fpsSlowCount++;
+                                if (fpsSlowCount >= FPS_ADJUST_SLOW_COUNT_THRESHOLD)
+                                {
+                                    fpsSlowCount = FPS_ADJUST_SLOW_COUNT_THRESHOLD;
+                                    inputState = InputState.FpsAdjustFast;
+                                    delay = SCAN_DELAY_FPS_ADJUST_FAST;
+                                }
+                                else
+                                {
+                                    delay = SCAN_DELAY_FPS_ADJUST_SLOW;
+                                }
+                            }
+                            break;
+                        case (InputState.FpsAdjustFast, _, false):
+                            {
+                                syncCtx.Post(_ => FpsAdjustPressed?.Invoke(this, fpsDirection * FPS_ADJUST_FAST_STEPIN), null);
+                                delay = SCAN_DELAY_FPS_ADJUST_FAST;
+                            }
+                            break;
+                        default:
+                            delay = SCAN_DELAY_NORMAL_KEY;
+                            break;
+                    }
+                    await Task.Delay(delay, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+            }
+            while (!cancellationToken.IsCancellationRequested);
+        }, cancellationToken);
+    }
+
+    public event EventHandler? KeyBPressed;
+    public event EventHandler? KeyYPressed;
+    public event EventHandler? KeyLCenterPressed;
+    public event EventHandler<int>? FpsAdjustPressed;
+
+    private CancellationTokenSource? _loopCancel;
+
+    public MainPageXInputService()
+    {
+        Native.XInputEnable(true);
+    }
+    public void PauseListening()
+    {
+        _loopCancel?.Cancel();
+    }
+    public void ResumeListening()
+    {
+        if (_loopCancel?.IsCancellationRequested is not false)
+        {
+            _loopCancel?.Cancel();
+            _loopCancel = new();
+            var syncCtx = SynchronizationContext.Current ?? throw new InvalidOperationException("No SynchronizationContext available");
+            var token = _loopCancel.Token;
+            StartLoop(syncCtx, token);
+        }
+    }
+}

--- a/unlockfps_nc/Utility/Native.cs
+++ b/unlockfps_nc/Utility/Native.cs
@@ -90,15 +90,15 @@ namespace unlockfps_nc.Utility
         [DllImport("kernel32.dll", SetLastError = true)]
         public static extern bool WriteProcessMemory(IntPtr hProcess, IntPtr lpBaseAddress, byte[] lpBuffer, int nSize, out int lpNumberOfBytesWritten);
 
-        [DllImport("kernel32.dll", SetLastError =true)]
+        [DllImport("kernel32.dll", SetLastError = true)]
         public static extern bool ReadProcessMemory(IntPtr hProcess, IntPtr lpBaseAddress, [Out] byte[] lpBuffer, int nSize, out int lpNumberOfBytesRead);
 
         [DllImport("kernel32.dll", SetLastError = true)]
         public static extern IntPtr CreateRemoteThread(IntPtr hProcess, IntPtr lpThreadAttributes, uint dwStackSize, IntPtr lpStartAddress, IntPtr lpParameter, uint dwCreationFlags, out uint lpThreadId);
-        
+
         [DllImport("kernel32.dll", SetLastError = true)]
         public static extern IntPtr VirtualAllocEx(IntPtr hProcess, IntPtr lpAddress, uint dwSize, uint flAllocationType, uint flProtect);
-        
+
         [DllImport("kernel32.dll", SetLastError = true)]
         public static extern bool VirtualFreeEx(IntPtr hProcess, IntPtr lpAddress, uint dwSize, uint dwFreeType);
 
@@ -140,6 +140,12 @@ namespace unlockfps_nc.Utility
 
         [DllImport("ntdll.dll")]
         public static extern uint RtlAdjustPrivilege(uint Privilege, bool bEnablePrivilege, bool IsThreadPrivilege, out bool PreviousValue);
+
+        [DllImport("Xinput1_4.dll")]
+        public static extern void XInputEnable(bool enable);
+
+        [DllImport("Xinput1_4.dll")]
+        public static extern uint XInputGetKeystroke(uint dwUserIndex, uint dwReserved, out XINPUT_KEYSTROKE pKeystroke);
 
         public static bool IsWine()
         {
@@ -192,7 +198,7 @@ namespace unlockfps_nc.Utility
         public const uint SET_LIMITED_INFORMATION = 0x2000;
         public const uint ALL_ACCESS = 0x1FFFFF;
     }
-    
+
     internal static class StandardAccess
     {
         public const uint DELETE = 0x00010000;
@@ -236,6 +242,34 @@ namespace unlockfps_nc.Utility
         public const uint READONLY = 0x02;
         public const uint READWRITE = 0x04;
         public const uint WRITECOPY = 0x08;
+    }
+
+    internal static class XUserIndex
+    {
+        public const uint XUSER_INDEX_ANY = 0x000000FF;
+    }
+
+    internal static class XKeystrokeCode
+    {
+        public const ushort VK_PAD_B = 0x5801;
+        public const ushort VK_PAD_Y = 0x5803;
+        public const ushort VK_PAD_LTHUMB_PRESS = 0x5816;
+        public const ushort VK_PAD_LTRIGGER = 0x5806;
+        public const ushort VK_PAD_RTRIGGER = 0x5807;
+    }
+
+    internal static class XKeystrokeFlags
+    {
+        public const ushort XINPUT_KEYSTROKE_KEYDOWN = 0x0001;
+        public const ushort XINPUT_KEYSTROKE_KEYUP = 0x0002;
+        public const ushort XINPUT_KEYSTROKE_REPEAT = 0x0004;
+    }
+
+    internal static class XInputGetKeystrokeResult 
+    {
+        public const uint ERROR_SUCCESS = 0;
+        public const uint ERROR_EMPTY = 4306;
+        public const uint ERROR_DEVICE_NOT_CONNECTED = 1167;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -382,5 +416,15 @@ namespace unlockfps_nc.Utility
         public IntPtr lpBaseOfDll;
         public uint SizeOfImage;
         public IntPtr EntryPoint;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct XINPUT_KEYSTROKE
+    {
+        public ushort VirtualKey;
+        public char Unicode;
+        public ushort Flags;
+        public byte UserIndex;
+        public byte HidCode;
     }
 }

--- a/unlockfps_nc/unlockfps_nc.csproj
+++ b/unlockfps_nc/unlockfps_nc.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows</TargetFramework>
-	<EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
This PR enables MainPage to respond to the following Xbox Controller events:

- Y key: `Start Game`
- B key: Hide main window
- L joystick press: Toggle `Start Game Automatically`
- L trigger/R trigger: adjust FPS

The reason I want this is mainly for the `Start Game` shortcut. With this change I won't need to use mouse to launch the game. <del>The others are ... for fun, just in case someone wants to kill time while waiting for resin to replenish.</del>