### PR TITLE
Fix Start minimized not working.

### DIFF
--- a/unlockfps_nc/MainForm.cs
+++ b/unlockfps_nc/MainForm.cs
@@ -49,6 +49,11 @@ namespace unlockfps_nc
             _windowSize = Size;
             if (_config.AutoStart)
                 BtnStartGame_Click(null, null);
+            if (_config.StartMinimized)
+            {
+                WindowState = FormWindowState.Minimized;
+                NotifyAndHide();
+            }
         }
 
         private void SetupBindings()

--- a/unlockfps_nc/SettingsForm.Designer.cs
+++ b/unlockfps_nc/SettingsForm.Designer.cs
@@ -154,7 +154,7 @@
             CBStartMinimized.Size = new Size(167, 19);
             CBStartMinimized.TabIndex = 1;
             CBStartMinimized.Text = "Start Minimized (Unlocker)";
-            ToolTipSettings.SetToolTip(CBStartMinimized, "Unlocker will minimized to tray on starup");
+            ToolTipSettings.SetToolTip(CBStartMinimized, "Unlocker will minimized to tray on startup");
             CBStartMinimized.UseVisualStyleBackColor = true;
             // 
             // TabLaunchOptions


### PR DESCRIPTION
A Start minimized option in Settings is available but not working due to missing code to minimize it when the application starts. This request adds that missing code.